### PR TITLE
Small improvements

### DIFF
--- a/bln-mode.el
+++ b/bln-mode.el
@@ -66,32 +66,33 @@
 
 ;;; Code:
 
-(defvar bln-beg -1)
-(defvar bln-end -1)
+(defvar bln-beg-end '(-1 . -1))
 (defvar bln-prev-mid -1)
 
 ;;;###autoload
 (defun bln-backward-half ()
   "This function is used in combination with `bln-forward-half' to provide binary line navigation (see `bln-mode')."
   (interactive)
-  (if (/= bln-prev-mid (point))
-      (setq bln-beg -1 bln-end -1)
-    (setq bln-end bln-prev-mid))
-  (if (< bln-beg 0) (setq bln-beg (line-beginning-position)
-			  bln-end (point)))
-  (setq bln-prev-mid (/ (+ bln-beg bln-end) 2))
+  (setq bln-beg-end
+        (if (/= bln-prev-mid (point))
+            '(-1 . -1)
+          `(,(car bln-beg-end) . ,bln-prev-mid)))
+  (when (< (car bln-beg-end) 0) (setq bln-beg-end
+                                      `(,(line-beginning-position) . ,(point))))
+  (setq bln-prev-mid (/ (+ (car bln-beg-end) (cdr bln-beg-end)) 2))
   (goto-char bln-prev-mid))
 
 ;;;###autoload
 (defun bln-forward-half ()
   "This function is used in combination with `bln-backward-half' to provide binary line navigation (see `bln-mode')."
   (interactive)
-  (if (/= bln-prev-mid (point))
-      (setq bln-beg -1 bln-end -1)
-    (setq bln-beg bln-prev-mid))
-  (if (< bln-end 0) (setq bln-beg (point)
-			  bln-end (line-end-position)))
-  (setq bln-prev-mid (/ (+ bln-beg bln-end ) 2))
+  (setq bln-beg-end
+        (if (/= bln-prev-mid (point))
+            '(-1 . -1)
+          `(,bln-prev-mid . ,(cdr bln-beg-end))))
+  (when (< (cdr bln-beg-end) 0) (setq bln-beg-end
+                                      `(,(point) . ,(line-end-position))))
+  (setq bln-prev-mid (/ (+ (car bln-beg-end) (cdr bln-beg-end)) 2))
   (goto-char bln-prev-mid))
 
 

--- a/bln-mode.el
+++ b/bln-mode.el
@@ -75,10 +75,8 @@
   (interactive)
   (setq bln-beg-end
         (if (/= bln-prev-mid (point))
-            '(-1 . -1)
+            `(,(line-beginning-position) . ,(point))
           `(,(car bln-beg-end) . ,bln-prev-mid)))
-  (when (< (car bln-beg-end) 0) (setq bln-beg-end
-                                      `(,(line-beginning-position) . ,(point))))
   (setq bln-prev-mid (/ (+ (car bln-beg-end) (cdr bln-beg-end)) 2))
   (goto-char bln-prev-mid))
 
@@ -88,10 +86,8 @@
   (interactive)
   (setq bln-beg-end
         (if (/= bln-prev-mid (point))
-            '(-1 . -1)
+            `(,(point) . ,(line-end-position))
           `(,bln-prev-mid . ,(cdr bln-beg-end))))
-  (when (< (cdr bln-beg-end) 0) (setq bln-beg-end
-                                      `(,(point) . ,(line-end-position))))
   (setq bln-prev-mid (/ (+ (car bln-beg-end) (cdr bln-beg-end)) 2))
   (goto-char bln-prev-mid))
 

--- a/bln-mode.el
+++ b/bln-mode.el
@@ -67,29 +67,29 @@
 ;;; Code:
 
 (defvar bln-beg-end '(-1 . -1))
-(defvar bln-prev-mid -1)
+(defvar bln-functions-list '(bln-backward-half
+                             bln-forward-half))
 
 ;;;###autoload
 (defun bln-backward-half ()
   "This function is used in combination with `bln-forward-half' to provide binary line navigation (see `bln-mode')."
   (interactive)
   (setq bln-beg-end
-        (if (/= bln-prev-mid (point))
-            `(,(line-beginning-position) . ,(point))
-          `(,(car bln-beg-end) . ,bln-prev-mid)))
-  (setq bln-prev-mid (/ (+ (car bln-beg-end) (cdr bln-beg-end)) 2))
-  (goto-char bln-prev-mid))
+        (if (member last-command bln-functions-list)
+            `(,(car bln-beg-end) . ,(point))
+          `(,(line-beginning-position) . ,(point))))
+  (goto-char (/ (+ (car bln-beg-end) (cdr bln-beg-end)) 2)))
 
 ;;;###autoload
 (defun bln-forward-half ()
   "This function is used in combination with `bln-backward-half' to provide binary line navigation (see `bln-mode')."
   (interactive)
   (setq bln-beg-end
-        (if (/= bln-prev-mid (point))
-            `(,(point) . ,(line-end-position))
-          `(,bln-prev-mid . ,(cdr bln-beg-end))))
-  (setq bln-prev-mid (/ (+ (car bln-beg-end) (cdr bln-beg-end)) 2))
-  (goto-char bln-prev-mid))
+        (if (member last-command bln-functions-list)
+            ;; (/= (point) bln-prev-point))
+            `(,(point) . ,(cdr bln-beg-end))
+          `(,(point) . ,(line-end-position))))
+  (goto-char (/ (+ (car bln-beg-end) (cdr bln-beg-end)) 2)))
 
 
 (defvar bln-mode-map (make-sparse-keymap) "Keymap for bln-mode.")


### PR DESCRIPTION
The main change is the following:
Before this change, the condition to know whether we were in the middle of a journey or not was to compare the cursor position with the position where the last movement in the journey have leave the cursor.
So, if one does a journey and after some edits the cursor ends up at the same position, then one needs to move the cursor before start a new journey.
It is just one keystroke, but now one does not need such extra keystroke.
With this code the transition between journeys is any keystroke which does not call a bln-* function.

I am mostly sure that the commit "Delete redundant condition" is ok, but maybe I am missing some point.